### PR TITLE
First implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# `go-depsync`
+
+`go-depsync` is a small command that identifies common dependencies with a given package, referred to as parent, and outputs a `go get` command that aligns the version of common dependencies with those of the parent package.
+
+It is useful for extensions and plugins that are built together with a core package, and whose dependencies need to be aligned for binary compatibility.
+
+## Usage
+
+`go-depsync` can be installed using `go install`:
+
+```console
+$ go install github.com/grafana/go-depsync
+```
+
+After that, it is ready to be used:
+
+```bash
+go-depsync --parent go.k6.io/k6
+```
+
+If the `go.mod` file for the local package is not on the working directory, a path to it can also be specified:
+
+```bash
+go-depsync --gomod /path/to/go.mod --parent go.k6.io/k6
+```
+
+`go-depsync` produces an output similar to the following:
+
+```console
+$ go-depsync --parent=go.k6.io/k6
+2023/11/17 12:59:01 Found parent go.k6.io/k6@v0.46.0
+2023/11/17 12:59:01 Mismatched versions for github.com/spf13/afero: v1.2.2 (this package) -> v1.1.2 (parent)
+2023/11/17 12:59:01 Mismatched versions for golang.org/x/sys: v0.11.0 (this package) -> v0.9.0 (parent)
+2023/11/17 12:59:01 Mismatched versions for github.com/spf13/cobra: v1.5.0 (this package) -> v1.4.0 (parent)
+2023/11/17 12:59:01 Mismatched versions for google.golang.org/grpc: v1.57.0 (this package) -> v1.56.1 (parent)
+go get github.com/spf13/afero@v1.1.2 golang.org/x/sys@v0.9.0 github.com/spf13/cobra@v1.4.0 google.golang.org/grpc@v1.56.1
+```
+
+The final line includes the `go get` command that, when run, will sync the versions of commons dependencies to those of the parent. `go-depsync` outputs this line to `stdout` so it can be piped to a shell, or redirected to a script for later use.
+
+## Trivia
+
+Go versions earlier than 1.21 have been observed to produce unexpected result when the `go get` command is run, sometimes ignoring some of the versions specified in the command, or unexpectedly upgrading/downgrading dependencies that are not present on it. It is recommended to run the `go get` commands suggested by `go-depsync` with Go >= 1.21.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ go-depsync --gomod /path/to/go.mod --parent go.k6.io/k6
 
 ```console
 $ go-depsync --parent=go.k6.io/k6
-2023/11/17 12:59:01 Found parent go.k6.io/k6@v0.46.0
-2023/11/17 12:59:01 Mismatched versions for github.com/spf13/afero: v1.2.2 (this package) -> v1.1.2 (parent)
-2023/11/17 12:59:01 Mismatched versions for golang.org/x/sys: v0.11.0 (this package) -> v0.9.0 (parent)
-2023/11/17 12:59:01 Mismatched versions for github.com/spf13/cobra: v1.5.0 (this package) -> v1.4.0 (parent)
-2023/11/17 12:59:01 Mismatched versions for google.golang.org/grpc: v1.57.0 (this package) -> v1.56.1 (parent)
-go get github.com/spf13/afero@v1.1.2 golang.org/x/sys@v0.9.0 github.com/spf13/cobra@v1.4.0 google.golang.org/grpc@v1.56.1
+2023/11/17 15:02:56 Found parent go.k6.io/k6@v0.46.0
+  DEPENDENCY              CURRENT VERSION  NEW VERSION
+  google.golang.org/grpc  v1.57.0          v1.56.1
+  github.com/spf13/cobra  v1.5.0           v1.4.0
+  golang.org/x/sys        v0.11.0          v0.9.0
+  github.com/spf13/afero  v1.2.2           v1.1.2
+
+go get google.golang.org/grpc@v1.56.1 github.com/spf13/cobra@v1.4.0 golang.org/x/sys@v0.9.0 github.com/spf13/afero@v1.1.2
 ```
 
 The final line includes the `go get` command that, when run, will sync the versions of commons dependencies to those of the parent. `go-depsync` outputs this line to `stdout` so it can be piped to a shell, or redirected to a script for later use.

--- a/deps/fetcher.go
+++ b/deps/fetcher.go
@@ -1,0 +1,66 @@
+package deps
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"golang.org/x/mod/modfile"
+)
+
+type Dependencies map[string]string
+
+// FromGomod returns a map of dependencies given the contents of a go.mod file.
+func FromGomod(gomod []byte) (Dependencies, error) {
+	parsed, err := modfile.Parse("go.mod", gomod, nil)
+	if err != nil {
+		return nil, fmt.Errorf("parsing contents: %w", err)
+	}
+
+	deps := make(map[string]string)
+	for _, req := range parsed.Require {
+		deps[req.Mod.Path] = req.Mod.Version
+	}
+
+	return deps, nil
+}
+
+// FromModule returns a map of dependencies for a given go module, given its name and version.
+// It retrieves the go.mod file from proxy.golang.org.
+func FromModule(pkg, version string) (Dependencies, error) {
+	url := fmt.Sprintf("https://proxy.golang.org/%s/@v/%s.mod", pkg, version)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("requesting %q: %w", url, err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("%q returned unexpected status %d", url, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %q: %w", url, err)
+	}
+
+	return FromGomod(data)
+}
+
+// FromGomodFile returns a map of dependencies given the path to a local go.mod file.
+func FromGomodFile(path string) (Dependencies, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening %q: %w", path, err)
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("reading %q: %w", path, err)
+	}
+
+	return FromGomod(data)
+}

--- a/deps/fetcher_test.go
+++ b/deps/fetcher_test.go
@@ -1,0 +1,65 @@
+package deps_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/go-depsync/deps"
+)
+
+func Test_FromGomod(t *testing.T) {
+	t.Parallel()
+
+	gomod := `
+module github.com/grafana/go-depsync
+
+go 1.21.4
+
+require golang.org/x/mod v0.14.0
+`
+
+	dependencies, err := deps.FromGomod([]byte(gomod))
+	if err != nil {
+		t.Fatalf("parsing dependencies from go.mod: %v", err)
+	}
+
+	expected := deps.Dependencies{
+		"golang.org/x/mod": "v0.14.0",
+	}
+
+	if diff := cmp.Diff(dependencies, expected); diff != "" {
+		t.Fatalf("dependencies do not match expected:\n%s", diff)
+	}
+}
+
+func Test_FromPackage(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		pacakge string
+		version string
+	}{
+		{
+			pacakge: "go.k6.io/k6",
+			version: "v0.47.0",
+		},
+		{
+			pacakge: "github.com/prometheus/prometheus",
+			version: "v0.35.0",
+		},
+	} {
+		tc := tc
+		t.Run(tc.pacakge, func(t *testing.T) {
+			t.Parallel()
+
+			dependencies, err := deps.FromModule(tc.pacakge, tc.version)
+			if err != nil {
+				t.Fatalf("fetching dependencies: %v", err)
+			}
+
+			if len(dependencies) == 0 {
+				t.Fatalf("expected to have at least one dependency, returned %d", len(dependencies))
+			}
+		})
+	}
+}

--- a/deps/matcher.go
+++ b/deps/matcher.go
@@ -1,0 +1,43 @@
+package deps
+
+import (
+	"fmt"
+	"log"
+)
+
+// Mismatched looks at the dependencies of a package and its parent, and returns the dependencies that are present in
+// both packages with the version they have on the parent package.
+func Mismatched(own, parent Dependencies) Dependencies {
+	mismatched := Dependencies{}
+
+	for dep, version := range own {
+		parentVersion, inParent := parent[dep]
+		if !inParent {
+			continue
+		}
+
+		if version == parentVersion {
+			continue
+		}
+
+		log.Printf("Mismatched versions for %s: %s (this package) -> %s (parent)", dep, version, parentVersion)
+		mismatched[dep] = parentVersion
+	}
+
+	return mismatched
+}
+
+// GoGetCommand returns a go get command that installs the provided dependencies and versions.
+func GoGetCommand(deps Dependencies) string {
+	if len(deps) == 0 {
+		return ""
+	}
+
+	cmd := "go get"
+
+	for dep, version := range deps {
+		cmd += fmt.Sprintf(" %s@%s", dep, version)
+	}
+
+	return cmd
+}

--- a/deps/matcher.go
+++ b/deps/matcher.go
@@ -2,7 +2,6 @@ package deps
 
 import (
 	"fmt"
-	"log"
 )
 
 // Mismatched looks at the dependencies of a package and its parent, and returns the dependencies that are present in
@@ -20,7 +19,6 @@ func Mismatched(own, parent Dependencies) Dependencies {
 			continue
 		}
 
-		log.Printf("Mismatched versions for %s: %s (this package) -> %s (parent)", dep, version, parentVersion)
 		mismatched[dep] = parentVersion
 	}
 

--- a/deps/matcher_test.go
+++ b/deps/matcher_test.go
@@ -1,0 +1,79 @@
+package deps_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/go-depsync/deps"
+)
+
+func Test_Mismatched(t *testing.T) {
+	own := deps.Dependencies{
+		"something.tld/1": "v1.0.0",
+		"something.tld/2": "v2.0.0",
+		"something.tld/3": "v3.0.0",
+		"something.tld/4": "v4.0.0",
+		"something.tld/5": "v5.0.0",
+		"something.tld/6": "v6.0.0",
+	}
+
+	parent := deps.Dependencies{
+		"something.tld/2": "v2.0.0",
+		"something.tld/3": "v9.9.9",
+		"something.tld/4": "v9.9.9",
+		"something.tld/8": "v8.0.0",
+		"something.tld/9": "v9.0.0",
+	}
+
+	expected := deps.Dependencies{
+		"something.tld/3": "v9.9.9",
+		"something.tld/4": "v9.9.9",
+	}
+
+	mismatched := deps.Mismatched(own, parent)
+	if diff := cmp.Diff(mismatched, expected); diff != "" {
+		t.Fatalf("mismatched dependencies do not match expected:\n%s", diff)
+	}
+}
+
+func Test_GoGetCommand(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		deps     deps.Dependencies
+		expected string
+	}{
+		{
+			name:     "No dependencies",
+			deps:     deps.Dependencies{},
+			expected: "",
+		},
+		{
+			name: "One dependency",
+			deps: deps.Dependencies{
+				"foo/bar": "v1.2.3",
+			},
+			expected: "go get foo/bar@v1.2.3",
+		},
+		{
+			name: "Several dependencies",
+			deps: deps.Dependencies{
+				"foo/bar": "v1.2.3",
+				"foo/baz": "v4.5.6",
+				"foo/boo": "v7.8.101",
+			},
+			expected: "go get foo/bar@v1.2.3 foo/baz@v4.5.6 foo/boo@v7.8.101",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := deps.GoGetCommand(tc.deps)
+			if diff := cmp.Diff(cmd, tc.expected); diff != "" {
+				t.Fatalf("command does not match expected:\n%s", diff)
+			}
+		})
+	}
+}

--- a/deps/table.go
+++ b/deps/table.go
@@ -1,0 +1,22 @@
+package deps
+
+import (
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+// WriteVersionTable writes to w an ascii table showing the dependency versions that have changed between old and new.
+// Dependencies present in old but not present in new are not printed out, and all dependencies in new are assumed to
+// be also in old.
+// This function is meant to be called with the output of Match as the value of new.
+func WriteVersionTable(w io.Writer, old, new Dependencies) {
+	tw := tablewriter.NewWriter(w)
+
+	tw.SetHeader([]string{"Dependency", "Current version", "New version"})
+	for dep, v := range new {
+		tw.Append([]string{dep, old[dep], v})
+	}
+
+	tw.Render()
+}

--- a/deps/table.go
+++ b/deps/table.go
@@ -12,6 +12,13 @@ import (
 // This function is meant to be called with the output of Match as the value of new.
 func WriteVersionTable(w io.Writer, old, new Dependencies) {
 	tw := tablewriter.NewWriter(w)
+	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetHeaderLine(false)
+	tw.SetAutoFormatHeaders(true)
+	tw.SetBorder(false)
+	tw.SetCenterSeparator("")
+	tw.SetColumnSeparator("")
+	tw.SetRowSeparator("")
 
 	tw.SetHeader([]string{"Dependency", "Current version", "New version"})
 	for dep, v := range new {

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,8 @@ require (
 	github.com/google/go-cmp v0.6.0
 	golang.org/x/mod v0.14.0
 )
+
+require (
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/grafana/go-depsync
+
+go 1.21
+
+require (
+	github.com/google/go-cmp v0.6.0
+	golang.org/x/mod v0.14.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/grafana/go-depsync/deps"
+)
+
+func main() {
+	gomod := flag.String("gomod", "./go.mod", "Path to the local go.mod file")
+	parent := flag.String("parent", "", "Name of the parent package to sync dependencies with")
+	flag.Parse()
+
+	if *parent == "" {
+		flag.Usage()
+		log.Fatalf("You must specify the name of the parent package")
+	}
+
+	ownDeps, err := deps.FromGomodFile(*gomod)
+	if err != nil {
+		log.Fatalf("Couldn't parse own dependencies: %v", err)
+	}
+
+	parentVer, hasParent := ownDeps[*parent]
+	if !hasParent {
+		log.Fatalf("Parent package %q not found in local go.mod %q", *parent, *gomod)
+	}
+
+	log.Printf("Found parent %s@%s", *parent, parentVer)
+
+	parentDeps, err := deps.FromModule(*parent, parentVer)
+	if err != nil {
+		log.Fatalf("Cannot parse dependencies of %q: %v", *parent, err)
+	}
+
+	fmt.Println(deps.GoGetCommand(deps.Mismatched(ownDeps, parentDeps)))
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/grafana/go-depsync/deps"
 )
@@ -35,5 +36,13 @@ func main() {
 		log.Fatalf("Cannot parse dependencies of %q: %v", *parent, err)
 	}
 
-	fmt.Println(deps.GoGetCommand(deps.Mismatched(ownDeps, parentDeps)))
+	mismatched := deps.Mismatched(ownDeps, parentDeps)
+	if len(mismatched) == 0 {
+		return
+	}
+
+	deps.WriteVersionTable(os.Stderr, ownDeps, mismatched)
+	fmt.Fprintln(os.Stderr)
+
+	fmt.Println(deps.GoGetCommand(mismatched))
 }


### PR DESCRIPTION
This PR adds the first implementation of the `go-depsync` tool, made k6-agnostic as a result of the discussion we had in https://github.com/grafana/xk6/pull/72