### PR TITLE
Allow unrelated modules synchronization

### DIFF
--- a/deps/fetcher_test.go
+++ b/deps/fetcher_test.go
@@ -36,23 +36,23 @@ func Test_FromPackage(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		pacakge string
+		target string
 		version string
 	}{
 		{
-			pacakge: "go.k6.io/k6",
+			target: "go.k6.io/k6",
 			version: "v0.47.0",
 		},
 		{
-			pacakge: "github.com/prometheus/prometheus",
+			target: "github.com/prometheus/prometheus",
 			version: "v0.35.0",
 		},
 	} {
 		tc := tc
-		t.Run(tc.pacakge, func(t *testing.T) {
+		t.Run(tc.target, func(t *testing.T) {
 			t.Parallel()
 
-			dependencies, err := deps.FromModule(tc.pacakge, tc.version)
+			dependencies, err := deps.FromModule(tc.target, tc.version)
 			if err != nil {
 				t.Fatalf("fetching dependencies: %v", err)
 			}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 func main() {
 	gomod := flag.String("gomod", "./go.mod", "Path to the local go.mod file")
 	parent := flag.String("parent", "", "Name of the parent package to sync dependencies with")
+	parentVer := flag.String("version", "", "Version of parent package")
 	flag.Parse()
 
 	if *parent == "" {
@@ -24,14 +25,18 @@ func main() {
 		log.Fatalf("Couldn't parse own dependencies: %v", err)
 	}
 
-	parentVer, hasParent := ownDeps[*parent]
-	if !hasParent {
-		log.Fatalf("Parent package %q not found in local go.mod %q", *parent, *gomod)
+	if *parentVer != "" {
+		log.Printf("Using parent %s@%s", *parent, *parentVer)
+	} else {
+		parentVer, hasParent := ownDeps[*parent]
+		if !hasParent {
+			log.Fatalf("Parent package %q not found in local go.mod %q", *parent, *gomod)
+		}
+
+		log.Printf("Found parent %s@%s", *parent, parentVer)
 	}
 
-	log.Printf("Found parent %s@%s", *parent, parentVer)
-
-	parentDeps, err := deps.FromModule(*parent, parentVer)
+	parentDeps, err := deps.FromModule(*parent, *parentVer)
 	if err != nil {
 		log.Fatalf("Cannot parse dependencies of %q: %v", *parent, err)
 	}


### PR DESCRIPTION
Extends the use cases to the comparison of unrelated modules. Useful when planning the integration of a new (downstream) dependency. 